### PR TITLE
chore: enhance Helm chart testing with K8s version matrix

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,40 +1,80 @@
 name: Lint and Test Charts
 
-on: pull_request
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'charts/**'
+      - '.github/workflows/lint-test.yml'
+  pull_request:
+    paths:
+      - 'charts/**'
+      - '.github/workflows/lint-test.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  lint-test:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Install Helm
-        uses: azure/setup-helm@v1
-
-      - uses: actions/setup-python@v2
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
         with:
-          python-version: 3.7
+          version: v3.14.0
 
-      - name: Install chart-testing
-        uses: helm/chart-testing-action@v2.0.1
-
-      - name: Run chart-testing (list-changed)
-        id: list-changed
-        run: |
-          changed=$(ct list-changed)
-          if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
-          fi
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.7.0
 
       - name: Run chart-testing (lint)
-        run: ct lint
+        run: ct lint --debug
 
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+  install-test:
+    needs: lint
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-version:
+          - 'v1.28.0'
+          - 'v1.29.0'
+          - 'v1.30.0'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.7.0
+
+      - name: Check for changed charts
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create KinD cluster (K8s ${{ matrix.kubernetes-version }})
         if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.10.0
+        with:
+          node_image: kindest/node:${{ matrix.kubernetes-version }}
 
       - name: Run chart-testing (install)
-        run: ct install
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --debug
+        timeout-minutes: 15

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,50 @@
+# OpenSSF Scorecard - Security scoring and visibility
+# Based on https://github.com/ossf/scorecard-action
+name: OpenSSF Scorecard
+
+on:
+  # Run on changes to main branch
+  push:
+    branches:
+      - main
+  # Weekly scan
+  schedule:
+    - cron: '0 6 * * 0'
+  # Allow manual trigger
+  workflow_dispatch:
+
+# Required permissions for scorecard
+permissions:
+  security-events: write  # Upload SARIF results
+  id-token: write         # For badge generation
+  contents: read
+  actions: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Update lint-test workflow with Kubernetes version matrix (v1.28, v1.29, v1.30)
- Update action versions to latest (checkout@v4, helm@v4, chart-testing@v2.7.0)
- Add concurrency controls to prevent duplicate workflow runs
- Add OpenSSF Scorecard workflow for security scoring

## Changes
- **lint-test.yml**: Enhanced with multi-K8s version testing matrix
- **scorecard.yml**: New workflow for OpenSSF security scoring

## Test plan
- [ ] Verify lint job runs successfully
- [ ] Verify install tests run on all 3 K8s versions
- [ ] Verify scorecard runs on main branch push

🤖 Generated with [Claude Code](https://claude.com/claude-code)